### PR TITLE
Add speakers page

### DIFF
--- a/content/events/2020-tokyo/_speakers.md
+++ b/content/events/2020-tokyo/_speakers.md
@@ -1,7 +1,0 @@
----
-title: Speakers
----
-
-## Call for Speakers
-
-The call for participation for a Kubernetes Community Days event is now open. Follow the [talk proposal submission](../cfp) process if you’d like to submit an idea.

--- a/content/events/2020-tokyo/speakers.md
+++ b/content/events/2020-tokyo/speakers.md
@@ -1,0 +1,7 @@
+---
+title: CFP
+---
+
+## Call for Speakers
+
+Kubernetes Community Days イベントの参加募集を開始しました。アイデアを提出したい方は、[トークプロポーザルの提出](../cfp) の手順に従ってください。


### PR DESCRIPTION
Speakers ページを追加します。タイトルがもともと Speakers でしたが、記述は CFP に関することなので、わかりやすさ優先でタイトルを CFP に変更しています。